### PR TITLE
Add Google Trends Slack notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,26 @@ Awesome TCM Resources
 * [臺灣原住民族藥用植物誌—邵族](https://www.gjtaiwan.com/new/?product=%E8%87%BA%E7%81%A3%E5%8E%9F%E4%BD%8F%E6%B0%91%E6%97%8F%E8%97%A5%E7%94%A8%E6%A4%8D%E7%89%A9%E8%AA%8C-%E9%82%B5%E6%97%8F)
 * [古今本草植物圖鑑](https://www.books.com.tw/products/0010860024)
 * [台灣植物資訊整合查詢系統](https://tai2.ntu.edu.tw/search/3)
+
+## Google Trends Slack Notifier
+
+This repository now includes a small utility to monitor Google Trends for
+Chinese medicine related keywords and send a summary to Slack.
+
+### Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a Slack Incoming Webhook and export the URL:
+   ```bash
+   export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
+   ```
+3. Run the script:
+   ```bash
+   python google_trends_to_slack.py
+   ```
+
+The script queries Google Trends for several keywords and posts a formatted
+report to the configured Slack channel.

--- a/google_trends_to_slack.py
+++ b/google_trends_to_slack.py
@@ -1,0 +1,79 @@
+import os
+import json
+import logging
+from typing import List
+
+import requests
+from pytrends.request import TrendReq
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+KEYWORDS = [
+    "Chinese Medicine",
+    "herbal product",
+    "Taiwanese herbal formula",
+]
+
+TIMEFRAME = "now 7-d"  # last 7 days
+
+SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL")
+
+
+def fetch_trends(keywords: List[str]):
+    pytrends = TrendReq(hl="en-US", tz=360)
+    results = []
+    for kw in keywords:
+        try:
+            pytrends.build_payload([kw], timeframe=TIMEFRAME)
+            interest = pytrends.interest_over_time()
+            if interest.empty:
+                dynamic = 0
+            else:
+                dynamic = interest[kw].iloc[-1] - interest[kw].iloc[0]
+            related = pytrends.related_queries()
+            rising = []
+            if kw in related and related[kw].get("rising") is not None:
+                rising_df = related[kw]["rising"]
+                rising = [row["query"] for _, row in rising_df.head(5).iterrows()]
+            results.append({
+                "keyword": kw,
+                "dynamic": dynamic,
+                "rising_queries": rising,
+            })
+        except Exception as e:
+            logger.exception("Failed to fetch trend for %s", kw)
+    return results
+
+
+def format_message(trends: List[dict]) -> str:
+    lines = ["*Google Trends Report*"]
+    for t in trends:
+        line = f"*{t['keyword']}*\nDynamic: {t['dynamic']}"
+        if t['rising_queries']:
+            line += "\nRising queries: " + ", ".join(t['rising_queries'])
+        lines.append(line)
+    return "\n\n".join(lines)
+
+
+def send_to_slack(message: str):
+    if not SLACK_WEBHOOK_URL:
+        logger.error("SLACK_WEBHOOK_URL environment variable not set")
+        return
+    payload = {"text": message}
+    resp = requests.post(SLACK_WEBHOOK_URL, data=json.dumps(payload), headers={'Content-Type': 'application/json'})
+    if resp.status_code != 200:
+        logger.error("Slack webhook failed with status %s: %s", resp.status_code, resp.text)
+    else:
+        logger.info("Message sent to Slack")
+
+
+def main():
+    trends = fetch_trends(KEYWORDS)
+    message = format_message(trends)
+    print(message)
+    send_to_slack(message)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytrends
+requests


### PR DESCRIPTION
## Summary
- add a Python utility to fetch Google Trends data and send to Slack
- document how to run the notifier
- include dependencies list

## Testing
- `python google_trends_to_slack.py` *(fails: ModuleNotFoundError)*
- `pip install -r requirements.txt` *(fails: could not install dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68478c6ddb548331a3f334a4e7af4ebf